### PR TITLE
Set up development environment (local PocketBase + Expo web)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Fair Weather Friends (`fwf`) is an **Expo SDK 53 / React Native** app backed by a
+**PocketBase** server and the **OpenWeatherMap** API. Standard dev/test/lint/build
+commands live in `package.json` scripts and `CLAUDE.md` — use those; the notes
+below only cover non-obvious, environment-specific caveats.
+
+### Stale docs / backend migration (important)
+- The backend migrated from **Supabase → PocketBase**. `CLAUDE.md` and the
+  `migrations and database set up/` SQL files still describe Supabase and are
+  **stale**. The live backend is PocketBase (`src/utils/pocketbase.ts`,
+  `pocketbase-deploy/pb_schema.json`, `Dockerfile`, `railway.json`).
+- Because of that migration, `npm test` currently **fails to run**: `jest.setup.js`
+  mocks `./src/utils/supabase`, which no longer exists (`Cannot find module`). This
+  is a pre-existing repo bug, not an environment problem — do not "fix" it as part
+  of unrelated work.
+
+### Backend: local PocketBase
+- The app defaults `EXPO_PUBLIC_POCKETBASE_URL` to `http://localhost:8080`
+  (`app.config.js`). Run a local PocketBase on that port for full functionality.
+- A PocketBase v0.26.x binary is installed at `~/.local/pocketbase/pocketbase`
+  with a superuser `admin@fwf.local` / `adminpassword123` and data dir
+  `~/.local/pocketbase/pb_data`. Start it with:
+  `~/.local/pocketbase/pocketbase serve --http=0.0.0.0:8080 --dir ~/.local/pocketbase/pb_data`
+  (run it in a tmux session so it stays up).
+- If collections are missing (fresh `pb_data`), apply the schema with
+  `node scripts/setup-local-pocketbase.mjs` (idempotent; reads
+  `pocketbase-deploy/pb_schema.json`). It opens the `users` sign-up rule so
+  public email sign-up works locally.
+
+### Running the app
+- **Web is the only runnable target on this Linux VM** (no iOS/Android simulator).
+  Run `npm run web` (Expo Router web via Metro on port 8081). `npm run ios` /
+  `npm run android` require simulators that are unavailable here.
+- Web bundling depends on two dependency fixes already committed to
+  `package.json`: `@lottiefiles/dotlottie-react` (optional web peer dep of
+  `lottie-react-native`) and a `react-async-hook@3.6.2` override (upstream `3.6.1`
+  ships a broken `module` field that breaks Metro web resolution). Keep these.
+- Native-only features (contacts, camera/selfies, location, haptics) are limited or
+  unavailable on web, but the auth/onboarding flow (sign up → phone → name) renders
+  and works.
+- Create a `.env` (git-ignored) if you need to point at a non-default backend, e.g.
+  `EXPO_PUBLIC_POCKETBASE_URL=...`. Weather/home features need
+  `EXPO_PUBLIC_OPENWEATHER_API_KEY`; sign-up and early onboarding work without it.
+
+### Verifying end to end
+- Hello-world check: load `http://localhost:8081/`, sign up with an email/password
+  on the login screen — it creates a record in the PocketBase `users` collection
+  and navigates to the phone-number onboarding screen.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@babel/runtime": "^7.28.2",
         "@expo/vector-icons": "^14.1.0",
+        "@lottiefiles/dotlottie-react": "^0.6.5",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
@@ -3001,6 +3002,26 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lottiefiles/dotlottie-react": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-react/-/dotlottie-react-0.6.5.tgz",
+      "integrity": "sha512-4jbye+HKHaiKwai4+bcAwJfMwW0L55cAGIN0ZKCz+EqXs1R3YhB08VYeRu2LwDUybThgFQnl/XkB4loCfA7t2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lottiefiles/dotlottie-web": "0.25.0",
+        "debounce": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@lottiefiles/dotlottie-web": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.25.0.tgz",
+      "integrity": "sha512-k+4tTckmy7y319qY4AlZiLm4dP95KLXfZd1l1jbss0qX/eyV4KKT+4iLuBfhoFSljfXmM15Oma+e8d663CHPyA==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -6227,6 +6248,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debounce": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
+      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -13282,9 +13315,9 @@
       }
     },
     "node_modules/react-async-hook": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/react-async-hook/-/react-async-hook-3.6.1.tgz",
-      "integrity": "sha512-YWBB2feVQF79t5u2raMPHlZ8975Jds+guCvkWVC4kRLDlSCouLsYpQm4DGSqPeHvoHYVVcDfqNayLZAXQmnxnw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/react-async-hook/-/react-async-hook-3.6.2.tgz",
+      "integrity": "sha512-RkwHCJ8V7I6umKZLHneapuTRWf+eO4LOj0qUwUDsSn27jrAOcW6ClbV3x22Z4hVxH9bA0zb7y+ozDJDJ8PnZoA==",
       "license": "MIT",
       "engines": {
         "node": ">=8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@babel/runtime": "^7.28.2",
     "@expo/vector-icons": "^14.1.0",
+    "@lottiefiles/dotlottie-react": "^0.6.5",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
@@ -92,6 +93,9 @@
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.4.0",
     "typescript": "~5.8.3"
+  },
+  "overrides": {
+    "react-async-hook": "3.6.2"
   },
   "private": true
 }

--- a/scripts/setup-local-pocketbase.mjs
+++ b/scripts/setup-local-pocketbase.mjs
@@ -1,0 +1,159 @@
+// Idempotent local PocketBase schema setup for Fair Weather Friends.
+//
+// Reads pocketbase-deploy/pb_schema.json (legacy PB export format) and applies
+// it to a locally running PocketBase instance via the admin API, translating
+// the legacy `schema`/`options` format to the current `fields` format.
+//
+// Usage (PocketBase must already be running):
+//   node scripts/setup-local-pocketbase.mjs
+//
+// Environment variables (all optional, defaults shown):
+//   PB_URL=http://localhost:8080
+//   PB_ADMIN_EMAIL=admin@fwf.local
+//   PB_ADMIN_PASSWORD=adminpassword123
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PB_URL = process.env.PB_URL || "http://localhost:8080";
+const PB_ADMIN_EMAIL = process.env.PB_ADMIN_EMAIL || "admin@fwf.local";
+const PB_ADMIN_PASSWORD = process.env.PB_ADMIN_PASSWORD || "adminpassword123";
+
+const schemaPath = path.join(__dirname, "..", "pocketbase-deploy", "pb_schema.json");
+const legacy = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+
+let token = "";
+const nameToId = {};
+
+async function api(method, endpoint, body) {
+    const res = await fetch(`${PB_URL}${endpoint}`, {
+        method,
+        headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: token } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    let json;
+    try { json = text ? JSON.parse(text) : {}; } catch { json = { raw: text }; }
+    if (!res.ok) {
+        throw new Error(`${method} ${endpoint} -> ${res.status}: ${JSON.stringify(json)}`);
+    }
+    return json;
+}
+
+function translateField(f) {
+    const base = { name: f.name, type: f.type, required: !!f.required };
+    const o = f.options || {};
+    switch (f.type) {
+        case "text":
+        case "number":
+        case "bool":
+        case "date":
+            return base;
+        case "json":
+            return { ...base, maxSize: o.maxSize || 2000000 };
+        case "file":
+            return {
+                ...base,
+                maxSelect: o.maxSelect || 1,
+                maxSize: o.maxSize || 5242880,
+                mimeTypes: o.mimeTypes || [],
+            };
+        case "select":
+            return { ...base, maxSelect: o.maxSelect || 1, values: o.values || [] };
+        case "relation": {
+            const collectionId = nameToId[o.collectionId] || o.collectionId;
+            return {
+                ...base,
+                collectionId,
+                cascadeDelete: !!o.cascadeDelete,
+                maxSelect: o.maxSelect || 1,
+            };
+        }
+        default:
+            return base;
+    }
+}
+
+async function ensureUsersCollection(def) {
+    const list = await api("GET", "/api/collections?perPage=200");
+    const existing = list.items.find((c) => c.name === "users");
+    if (!existing) throw new Error("Default 'users' auth collection not found");
+    nameToId["users"] = existing.id;
+
+    const existingNames = new Set(existing.fields.map((f) => f.name));
+    const newFields = def.schema
+        .filter((f) => !existingNames.has(f.name))
+        .map(translateField);
+
+    const payload = {
+        fields: [...existing.fields, ...newFields],
+        // Allow public sign-up and let authenticated users read profiles (needed for friends).
+        createRule: "",
+        listRule: "@request.auth.id != ''",
+        viewRule: "@request.auth.id != ''",
+        updateRule: "@request.auth.id = id",
+    };
+    await api("PATCH", `/api/collections/${existing.id}`, payload);
+    console.log(`users: ensured (${newFields.length} custom field(s) added)`);
+}
+
+async function ensureBaseCollection(def) {
+    const list = await api("GET", "/api/collections?perPage=200");
+    const existing = list.items.find((c) => c.name === def.name);
+    if (existing) {
+        nameToId[def.name] = existing.id;
+        console.log(`${def.name}: already exists, skipping`);
+        return;
+    }
+    const fields = def.schema.map(translateField);
+    const payload = {
+        name: def.name,
+        type: "base",
+        fields,
+        // Permissive rules for local development.
+        listRule: "@request.auth.id != ''",
+        viewRule: "@request.auth.id != ''",
+        createRule: "@request.auth.id != ''",
+        updateRule: "@request.auth.id != ''",
+        deleteRule: "@request.auth.id != ''",
+        ...(def.indexes ? { indexes: def.indexes } : {}),
+    };
+    const created = await api("POST", "/api/collections", payload);
+    nameToId[def.name] = created.id;
+    console.log(`${def.name}: created`);
+}
+
+async function main() {
+    const auth = await api("POST", "/api/collections/_superusers/auth-with-password", {
+        identity: PB_ADMIN_EMAIL,
+        password: PB_ADMIN_PASSWORD,
+    });
+    token = auth.token;
+
+    // Pre-populate name->id for existing collections so relations resolve.
+    const list = await api("GET", "/api/collections?perPage=200");
+    for (const c of list.items) nameToId[c.name] = c.id;
+
+    for (const def of legacy) {
+        if (def.type === "auth" && def.name === "users") {
+            await ensureUsersCollection(def);
+        }
+    }
+    // Base collections in file order (users & plants precede their dependents).
+    for (const def of legacy) {
+        if (def.type === "base") {
+            await ensureBaseCollection(def);
+        }
+    }
+    console.log("PocketBase schema setup complete.");
+}
+
+main().catch((err) => {
+    console.error(err.message || err);
+    process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Fair Weather Friends so the app can be run and tested locally on a headless Linux VM.

- Adds `scripts/setup-local-pocketbase.mjs`, an idempotent helper that applies `pocketbase-deploy/pb_schema.json` to a locally running PocketBase instance (translating the legacy PB export format to the current collections API, opening the `users` sign-up rule, and creating all base collections).
- Adds `@lottiefiles/dotlottie-react` (the optional web peer dependency of `lottie-react-native`) so the Expo **web** target bundles.
- Pins the transitive `react-async-hook` to `3.6.2` via `overrides` to fix a broken `module` field in `3.6.1` that broke Metro web resolution.
- Adds `AGENTS.md` with durable Cursor Cloud run/startup instructions.

No application/runtime code was modified — only dependency setup, a new setup helper, and docs.

## Walkthrough

Signing up a new user through the app UI (Expo web) creates a PocketBase `users` record and advances to onboarding:

[fwf_signup_hello_world.mp4](https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffwf_signup_hello_world.mp4)

[Login screen](https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffwf_login_screen.webp)
[Onboarding screen after sign up](https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffwf_phone_onboarding_after_signup.webp)

## Notes
- The backend migrated from Supabase (still referenced in `CLAUDE.md` and `jest.setup.js`) to PocketBase. `npm test` currently fails on a pre-existing stale `./src/utils/supabase` mock reference in `jest.setup.js` — left unchanged since it is not an environment issue.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

