### PR TITLE
Fix plant growth, XP fetching, and harden the phone-based social graph

### DIFF
--- a/pocketbase-deploy/pb_schema.json
+++ b/pocketbase-deploy/pb_schema.json
@@ -145,7 +145,10 @@
       "allowOAuth2Auth": false,
       "minPasswordLength": 8,
       "requireEmail": true
-    }
+    },
+    "indexes": [
+      "CREATE UNIQUE INDEX `idx_users_phone_number` ON `users` (`phone_number`) WHERE `phone_number` != ''"
+    ]
   },
   {
     "name": "plants",

--- a/scripts/setup-local-pocketbase.mjs
+++ b/scripts/setup-local-pocketbase.mjs
@@ -102,15 +102,33 @@ async function ensureUsersCollection(def) {
     console.log(`users: ensured (${newFields.length} custom field(s) added)`);
 }
 
+// PocketBase 0.23+ no longer auto-creates created/updated fields; the app sorts
+// by `created` (e.g. XP history, activity feed), so add them explicitly.
+const AUTODATE_FIELDS = [
+    { name: "created", type: "autodate", onCreate: true, onUpdate: false },
+    { name: "updated", type: "autodate", onCreate: true, onUpdate: true },
+];
+
 async function ensureBaseCollection(def) {
     const list = await api("GET", "/api/collections?perPage=200");
     const existing = list.items.find((c) => c.name === def.name);
     if (existing) {
         nameToId[def.name] = existing.id;
-        console.log(`${def.name}: already exists, skipping`);
+        // Backfill created/updated autodate fields if a prior run created the
+        // collection without them.
+        const existingNames = new Set(existing.fields.map((f) => f.name));
+        const missing = AUTODATE_FIELDS.filter((f) => !existingNames.has(f.name));
+        if (missing.length > 0) {
+            await api("PATCH", `/api/collections/${existing.id}`, {
+                fields: [...existing.fields, ...missing],
+            });
+            console.log(`${def.name}: added ${missing.map((f) => f.name).join(", ")}`);
+        } else {
+            console.log(`${def.name}: already exists, skipping`);
+        }
         return;
     }
-    const fields = def.schema.map(translateField);
+    const fields = [...def.schema.map(translateField), ...AUTODATE_FIELDS];
     const payload = {
         name: def.name,
         type: "base",

--- a/scripts/setup-local-pocketbase.mjs
+++ b/scripts/setup-local-pocketbase.mjs
@@ -90,8 +90,16 @@ async function ensureUsersCollection(def) {
         .filter((f) => !existingNames.has(f.name))
         .map(translateField);
 
+    // Merge our extra indexes (e.g. unique phone_number) with PocketBase's
+    // built-in ones (unique email/tokenKey) so we don't drop the defaults.
+    const existingIndexes = existing.indexes || [];
+    const extraIndexes = (def.indexes || []).filter(
+        (idx) => !existingIndexes.includes(idx)
+    );
+
     const payload = {
         fields: [...existing.fields, ...newFields],
+        indexes: [...existingIndexes, ...extraIndexes],
         // Allow public sign-up and let authenticated users read profiles (needed for friends).
         createRule: "",
         listRule: "@request.auth.id != ''",
@@ -99,7 +107,9 @@ async function ensureUsersCollection(def) {
         updateRule: "@request.auth.id = id",
     };
     await api("PATCH", `/api/collections/${existing.id}`, payload);
-    console.log(`users: ensured (${newFields.length} custom field(s) added)`);
+    console.log(
+        `users: ensured (${newFields.length} custom field(s), ${extraIndexes.length} extra index(es) added)`
+    );
 }
 
 // PocketBase 0.23+ no longer auto-creates created/updated fields; the app sorts

--- a/src/app/phone-number-add.tsx
+++ b/src/app/phone-number-add.tsx
@@ -22,6 +22,7 @@ const TypedPhoneInput = PhoneInput as unknown as ComponentType<PhoneInputProps>;
 export default function PhoneNumberAdd() {
     const [phone, setPhone] = useState("");
     const [formattedPhone, setFormattedPhone] = useState("");
+    const [countryCode, setCountryCode] = useState("US");
     const [loading, setLoading] = useState(false);
     const [isValid, setIsValid] = useState(false);
     const phoneInput = useRef<PhoneInput>(null);
@@ -42,7 +43,8 @@ export default function PhoneNumberAdd() {
 
         try {
             await pb.collection("users").update(user.id, {
-                phone_number: formattedPhone
+                phone_number: formattedPhone,
+                country_code: countryCode,
             });
             router.replace("/name-input");
         } catch (error: any) {
@@ -74,6 +76,9 @@ export default function PhoneNumberAdd() {
                     defaultCode="US"
                     layout="second"
                     autoFocus={true}
+                    onChangeCountry={(country: { cca2: string }) =>
+                        setCountryCode(country.cca2)
+                    }
                     onChangeText={setPhone}
                     onChangeFormattedText={(text) => {
                         setFormattedPhone(text);

--- a/src/services/gardenService.ts
+++ b/src/services/gardenService.ts
@@ -114,6 +114,7 @@ export class GardenService {
             garden_owner: friendId,
             planter: userId,
             plant: plantId,
+            planted_at: new Date().toISOString(),
             current_stage: 2,
             is_mature: false,
             slot: slotIdx,

--- a/src/services/xpService.ts
+++ b/src/services/xpService.ts
@@ -235,35 +235,14 @@ export class XPService {
         return [];
       }
 
-      // Use native fetch to bypass PocketBase SDK issues in React Native
-      const url = 'https://fwf-pocketbase-production.up.railway.app/api/collections/xp_transactions/records?perPage=200';
-      console.log('[XPService] 🔍 Fetching XP history URL:', url);
-
-      const response = await fetch(url);
-
-      console.log('[XPService] 📡 getXPHistory response status:', response.status, response.ok);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[XPService] ❌ getXPHistory fetch failed:", response.status, errorText);
-        return [];
-      }
-
-      const data = await response.json();
-      const allTransactions = data.items || [];
-
-      // Sort by created date descending in JS
-      const sortedTransactions = allTransactions.sort((a: any, b: any) =>
-        new Date(b.created).getTime() - new Date(a.created).getTime()
-      );
-
-      // Filter for this user
-      const userTransactions = sortedTransactions.filter((item: any) => item.user === userId);
+      // Authenticated, server-side filtered query scoped to this user's records.
+      const userTransactions = await pb.collection('xp_transactions').getFullList({
+        filter: pb.filter('user = {:userId}', { userId }),
+        sort: '-created',
+      });
 
       // Apply pagination
-      const startIdx = offset;
-      const endIdx = Math.min(startIdx + limit, userTransactions.length);
-      const paginatedTransactions = userTransactions.slice(startIdx, endIdx);
+      const paginatedTransactions = userTransactions.slice(offset, offset + limit);
 
       return paginatedTransactions.map((item: any) => ({
         id: item.id,
@@ -290,27 +269,11 @@ export class XPService {
         return 0;
       }
 
-      // Use native fetch to bypass PocketBase SDK issues in React Native
-      const url = 'https://fwf-pocketbase-production.up.railway.app/api/collections/xp_transactions/records?perPage=200';
-      console.log('[XPService] 🔍 Fetching XP for action URL:', url);
-
-      const response = await fetch(url);
-
-      console.log('[XPService] 📡 getTotalXPForAction response status:', response.status, response.ok);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[XPService] ❌ getTotalXPForAction fetch failed:", response.status, errorText);
-        return 0;
-      }
-
-      const data = await response.json();
-      const allTransactions = data.items || [];
-
-      // Filter for this user and action type
-      const result = allTransactions.filter(
-        (item: any) => item.user === userId && item.action_type === actionType
-      );
+      // Authenticated, server-side filtered query for this user's records of
+      // the given action type.
+      const result = await pb.collection('xp_transactions').getFullList({
+        filter: pb.filter('user = {:userId} && action_type = {:actionType}', { userId, actionType }),
+      });
 
       return result.reduce((sum: number, transaction: any) => sum + (transaction.amount || 0), 0);
 
@@ -329,25 +292,10 @@ export class XPService {
         return {};
       }
 
-      // Use native fetch to bypass PocketBase SDK issues in React Native
-      const url = 'https://fwf-pocketbase-production.up.railway.app/api/collections/xp_transactions/records?perPage=200';
-      console.log('[XPService] 🔍 Fetching XP statistics URL:', url);
-
-      const response = await fetch(url);
-
-      console.log('[XPService] 📡 getXPStatistics response status:', response.status, response.ok);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[XPService] ❌ getXPStatistics fetch failed:", response.status, errorText);
-        return {};
-      }
-
-      const data = await response.json();
-      const allTransactions = data.items || [];
-
-      // Filter for this user
-      const result = allTransactions.filter((item: any) => item.user === userId);
+      // Authenticated, server-side filtered query scoped to this user's records.
+      const result = await pb.collection('xp_transactions').getFullList({
+        filter: pb.filter('user = {:userId}', { userId }),
+      });
 
       const stats: Record<string, number> = {};
       result.forEach((transaction: any) => {
@@ -373,29 +321,13 @@ export class XPService {
     try {
       if (!userId) return false;
 
-      // Use native fetch to bypass PocketBase SDK issues in React Native
-      // Hardcode URL for testing
-      const url = 'https://fwf-pocketbase-production.up.railway.app/api/collections/xp_transactions/records?perPage=100';
-      console.log('[XPService] 🔍 Fetching URL:', url);
-
-      const response = await fetch(url);
-
-      console.log('[XPService] 📡 Response status:', response.status, response.ok);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[XPService] ❌ Fetch failed:", response.status, errorText);
-        return false;
-      }
-
-      const data = await response.json();
-      console.log('[XPService] ✅ Data received, items count:', data.items?.length || 0);
-      const items = data.items || [];
-
-      // Filter for this user's daily_use transactions in JS
-      const userDailyTransactions = items.filter(
-        (item: any) => item.user === userId && item.action_type === 'daily_use'
-      );
+      // Authenticated, server-side filtered query for this user's daily rewards.
+      const userDailyTransactions = await pb.collection('xp_transactions').getFullList({
+        filter: pb.filter('user = {:userId} && action_type = {:actionType}', {
+          userId,
+          actionType: 'daily_use',
+        }),
+      });
 
       if (userDailyTransactions.length === 0) {
         return true; // No daily XP transactions ever


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Core-functionality fixes plus two onboarding correctness fixes for the phone-based friend graph.

### 1. Plants never grew — `planted_at` was not set
`GardenService.plantSeed` created `planted_plants` without `planted_at`, so it stored as `""` and growth (computed from `planted_at`) always saw 0 elapsed hours — plants were stuck at stage 2 forever. Now sets `planted_at: new Date().toISOString()`.

### 2. `XPService` fetched a hardcoded production URL, unauthenticated
`getXPHistory`, `getTotalXPForAction`, `getXPStatistics`, and `canReceiveDailyXP` used `fetch()` against `https://fwf-pocketbase-production.up.railway.app/...` — ignoring `EXPO_PUBLIC_POCKETBASE_URL`, sending no auth, and pulling **all users'** transactions before filtering client-side (data exposure + an unreliable daily check past the page cap). Replaced with authenticated `pb.collection('xp_transactions')` queries filtered server-side by user via `pb.filter()`.

### 3. Persist `country_code` during phone onboarding
`phone-number-add` now captures the country picker's selection (`cca2`) and saves it as `country_code`. Contact matching normalizes numbers to E.164 using `country_code`; it was never written before and always fell back to `US`, so non-US users' contacts failed to match.

### 4. Unique index on `users.phone_number`
Prevents two accounts from claiming the same number (the app's social matching key). Partial index (`WHERE phone_number != ''`) so the many in-progress signups with an empty phone number don't collide. Added to the committed schema (`pocketbase-deploy/pb_schema.json`) and the local setup script (merged with PocketBase's default `email`/`tokenKey` indexes).

### Setup script
`scripts/setup-local-pocketbase.mjs` also now adds `created`/`updated` autodate fields to base collections (PocketBase 0.23+ dropped auto-creation; the app sorts by `created`).

No application auth/runtime behavior was changed beyond the above; email remains the login identity (recommended to defer removing it until the future OTP migration).

## Walkthrough

`country_code` persistence — selecting United Kingdom in onboarding stores `country_code: GB` (+ `phone_number: +447911123456`) on the user:

[country_code_persisted_uk.mp4](https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcountry_code_persisted_uk.mp4)

## Testing

- ✅ `npx tsc --noEmit` — no new type errors in edited source files.
- ✅ Web bundles cleanly with all changes.
- ✅ **#1** real `GrowthService` in Node: `planted_at=""` → `{stage:2, progress:0}`; `2h`/3h plant → `{stage:4, progress:67}`; `3.1h` → `{stage:5, progress:100}`.
- ✅ **#2** ran the new `pb.filter` + `getFullList` pattern against local PocketBase: only the target user's rows returned; `getTotalXPForAction` = `20` (excludes another user's `999`); daily check returns `false` after a same-day reward; no cross-user leak.
- ✅ **#3** end-to-end via the web UI: signed up, selected United Kingdom (+44), continued — verified `country_code: GB` persisted in PocketBase.
- ✅ **#4** against local PocketBase: two empty phone numbers both succeed (partial index), duplicate non-empty number rejected (HTTP 400), distinct number succeeds; default `email`/`tokenKey` indexes preserved.

## Follow-ups (not in this PR)
- Points/XP updates still use non-atomic read-modify-write (lost-update race / possible double-harvest) — recommend atomic `+`/`-` field modifiers and a guarded `harvested_at` update.
- Phone-first auth / removing email — recommend bundling with the future SMS OTP migration (PocketBase's built-in `requestOTP`/`authWithOTP` + a pay-as-you-go SMS provider), since it reorders onboarding and changes the login identity.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

