### PR TITLE
Ship PocketBase schema migration (push_token + phone_number unique index)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ RUN mkdir -p /pb/pb_data
 # Ship server-side hooks (garden-activity push notifications, etc.)
 COPY pb_hooks /pb/pb_hooks
 
+# Ship schema migrations (auto-applied on startup by PocketBase's automigrate)
+COPY pb_migrations /pb/pb_migrations
+
 # Expose the default PocketBase port
 EXPOSE 8080
 
 # Start PocketBase
-ENTRYPOINT ["/pb/pocketbase", "serve", "--http=0.0.0.0:8080", "--dir=/pb/pb_data", "--hooksDir=/pb/pb_hooks"]
+ENTRYPOINT ["/pb/pocketbase", "serve", "--http=0.0.0.0:8080", "--dir=/pb/pb_data", "--hooksDir=/pb/pb_hooks", "--migrationsDir=/pb/pb_migrations"]

--- a/pb_migrations/1783036800_add_push_token_and_phone_index.js
+++ b/pb_migrations/1783036800_add_push_token_and_phone_index.js
@@ -1,0 +1,45 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Applies the users-collection schema changes needed in production:
+//   - push_token: stores the device's Expo push token (garden-activity pushes)
+//   - a partial unique index on phone_number (the social matching key)
+//
+// Guarded so it's safe even if the field/index were already added manually via
+// the Admin UI. Auto-applied on startup by PocketBase's automigrate.
+migrate(
+    (app) => {
+        const users = app.findCollectionByNameOrId("users");
+
+        if (!users.fields.getByName("push_token")) {
+            users.fields.add(
+                new Field({
+                    name: "push_token",
+                    type: "text",
+                })
+            );
+        }
+
+        // Partial index so the many in-progress signups with an empty
+        // phone_number don't collide, while real numbers stay unique.
+        // Guarded on the field existing so this can never break startup on an
+        // instance that predates the phone_number field.
+        const phoneIndex =
+            "CREATE UNIQUE INDEX `idx_users_phone_number` ON `users` (`phone_number`) WHERE `phone_number` != ''";
+        if (
+            users.fields.getByName("phone_number") &&
+            !users.indexes.find((i) => i.includes("idx_users_phone_number"))
+        ) {
+            users.indexes.push(phoneIndex);
+        }
+
+        app.save(users);
+    },
+    (app) => {
+        const users = app.findCollectionByNameOrId("users");
+        users.fields.removeByName("push_token");
+        users.indexes = users.indexes.filter(
+            (i) => !i.includes("idx_users_phone_number")
+        );
+        app.save(users);
+    }
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR #60 was merged at the notification-hook commit, **before** the schema-migration commit landed, so the migration never made it onto `main`. As a result:
- the garden-activity push hook is live, but prod has no `push_token` field for it to read;
- the `phone_number` unique index isn't auto-applied to prod.

This PR carries the missing commit (cherry-picked) onto `main`.

## What

- `pb_migrations/1783036800_add_push_token_and_phone_index.js` — auto-applied on deploy by PocketBase's automigrate. Adds the `push_token` field and the partial unique index on `phone_number`. Guarded/idempotent: safe to re-run, and it won't break startup on an instance that doesn't yet have a `phone_number` field (the index is only created when the field exists).
- `Dockerfile` — ships `pb_migrations` and loads it via `--migrationsDir` (complements the `pb_hooks`/`--hooksDir` wiring already on `main`).

## Testing (local PocketBase, done when the commit was first authored)

- ✅ Fresh DB (no `phone_number`): server boots cleanly, `push_token` added, index safely skipped.
- ✅ Prod-like DB (`phone_number` present): `push_token` added **and** the partial unique index created; a duplicate non-empty phone number is then rejected (400).

## Deploy notes
- On the next Railway deploy the migration applies automatically (adds `push_token` + the phone index).
- Ensure `/pb/pb_data` is a persistent Railway volume so migrations/data survive redeploys.
- Resolve any pre-existing duplicate non-empty `phone_number` values before deploying, or the unique-index creation will fail.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

