### PR TITLE
Bump react-native-reanimated to ~3.17.4 (fix iOS build on SDK 53 / RN 0.79)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-native-chart-kit": "^6.12.0",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-phone-number-input": "^2.1.0",
-        "react-native-reanimated": "^3.16.7",
+        "react-native-reanimated": "~3.17.4",
         "react-native-reanimated-carousel": "^4.0.2",
         "react-native-safe-area-context": "^5.4.0",
         "react-native-screens": "~4.11.1",
@@ -13668,9 +13668,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.16.7",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.16.7.tgz",
-      "integrity": "sha512-qoUUQOwE1pHlmQ9cXTJ2MX9FQ9eHllopCLiWOkDkp6CER95ZWeXhJCP4cSm6AD4jigL5jHcZf/SkWrg8ttZUsw==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
+      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
@@ -13683,7 +13683,8 @@
         "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
         "@babel/preset-typescript": "^7.16.7",
         "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4"
+        "invariant": "^2.2.4",
+        "react-native-is-edge-to-edge": "1.1.7"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0",
@@ -13701,6 +13702,16 @@
         "react-native": ">=0.70.3",
         "react-native-gesture-handler": ">=2.9.0",
         "react-native-reanimated": ">=3.0.0"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
+      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-native-chart-kit": "^6.12.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-phone-number-input": "^2.1.0",
-    "react-native-reanimated": "^3.16.7",
+    "react-native-reanimated": "~3.17.4",
     "react-native-reanimated-carousel": "^4.0.2",
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "~4.11.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

A clean install + `npx expo run:ios` fails to compile with:

```
node_modules/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.cpp:34
  no member named 'parentShadowView' in 'facebook::react::ShadowViewMutation'
```

Root cause: `package.json` pinned `react-native-reanimated` at `^3.16.7`, and the lockfile resolved the floor `3.16.7`, which predates RN 0.79's Fabric `ShadowViewMutation` API. Expo SDK 53 ships reanimated `~3.17.4`, which matches RN 0.79.

## Change

- `react-native-reanimated`: `^3.16.7` → `~3.17.4` (installs `3.17.5`), plus the lockfile update.

Pinning with `~` keeps it on the SDK-correct 3.17.x line and prevents an incompatible floor from being installed again.

## Testing

- ✅ `npm install --legacy-peer-deps` resolves `react-native-reanimated@3.17.5`.
- ✅ Metro **web** bundle builds cleanly with the new version (JS-level sanity: 1820 modules, no errors).
- ⚠️ The iOS native compile itself can't run in this Linux environment; `~3.17.4` is the version Expo SDK 53 pairs with RN 0.79, which is the known-good combination that resolves the `parentShadowView` error. Please confirm with `npx expo run:ios` after `npm install --legacy-peer-deps` + `pod install`.

## Note on other version drift (not changed here)
An SDK-compatibility scan shows several other deps sit slightly off Expo SDK 53's expected versions (e.g. `expo-image`, `expo-router`, `react-native` `0.79.4` vs `0.79.5`, `react-native-svg`), but they're within compatible ranges and every other pod compiled fine — only reanimated's floor was build-breaking. Aligning the rest via `npx expo install --fix` is worth doing as a separate, deliberately-tested change (it would bump `react-native` itself), so I've left it out of this focused fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

