### PR TITLE
Core fixes on SDK 55: plant growth, XP queries, country_code, phone unique index

### DIFF
--- a/pb_migrations/1783117000_add_phone_number_unique_index.js
+++ b/pb_migrations/1783117000_add_phone_number_unique_index.js
@@ -1,0 +1,27 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Adds a partial unique index on users.phone_number (the app's social matching
+// key) so two accounts can't claim the same number. The WHERE clause keeps the
+// many in-progress signups with an empty phone_number from colliding.
+// Guarded so it can't break startup on an instance without a phone_number field.
+migrate(
+    (app) => {
+        const users = app.findCollectionByNameOrId("users");
+        const phoneIndex =
+            "CREATE UNIQUE INDEX `idx_users_phone_number` ON `users` (`phone_number`) WHERE `phone_number` != ''";
+        if (
+            users.fields.getByName("phone_number") &&
+            !users.indexes.find((i) => i.includes("idx_users_phone_number"))
+        ) {
+            users.indexes.push(phoneIndex);
+            app.save(users);
+        }
+    },
+    (app) => {
+        const users = app.findCollectionByNameOrId("users");
+        users.indexes = users.indexes.filter(
+            (i) => !i.includes("idx_users_phone_number")
+        );
+        app.save(users);
+    }
+);

--- a/pocketbase-deploy/pb_schema.json
+++ b/pocketbase-deploy/pb_schema.json
@@ -145,7 +145,10 @@
       "allowOAuth2Auth": false,
       "minPasswordLength": 8,
       "requireEmail": true
-    }
+    },
+    "indexes": [
+      "CREATE UNIQUE INDEX `idx_users_phone_number` ON `users` (`phone_number`) WHERE `phone_number` != ''"
+    ]
   },
   {
     "name": "plants",

--- a/src/app/phone-number-add.tsx
+++ b/src/app/phone-number-add.tsx
@@ -22,6 +22,7 @@ const TypedPhoneInput = PhoneInput as unknown as ComponentType<PhoneInputProps>;
 export default function PhoneNumberAdd() {
     const [phone, setPhone] = useState("");
     const [formattedPhone, setFormattedPhone] = useState("");
+    const [countryCode, setCountryCode] = useState("US");
     const [loading, setLoading] = useState(false);
     const [isValid, setIsValid] = useState(false);
     const phoneInput = useRef<PhoneInput>(null);
@@ -42,7 +43,8 @@ export default function PhoneNumberAdd() {
 
         try {
             await pb.collection("users").update(user.id, {
-                phone_number: formattedPhone
+                phone_number: formattedPhone,
+                country_code: countryCode,
             });
             router.replace("/name-input");
         } catch (error: any) {
@@ -72,6 +74,9 @@ export default function PhoneNumberAdd() {
                 <PhoneInput
                     ref={phoneInput}
                     defaultCode="US"
+                    onChangeCountry={(country: { cca2: string }) =>
+                        setCountryCode(country.cca2)
+                    }
                     layout="second"
                     autoFocus={true}
                     onChangeText={setPhone}

--- a/src/services/gardenService.ts
+++ b/src/services/gardenService.ts
@@ -114,6 +114,7 @@ export class GardenService {
             garden_owner: friendId,
             planter: userId,
             plant: plantId,
+            planted_at: new Date().toISOString(),
             current_stage: 2,
             is_mature: false,
             slot: slotIdx,

--- a/src/services/xpService.ts
+++ b/src/services/xpService.ts
@@ -235,39 +235,14 @@ export class XPService {
         return [];
       }
 
-      // Use native fetch to bypass PocketBase SDK issues in React Native
-      const url = 'https://fwf-pocketbase-production.up.railway.app/api/collections/xp_transactions/records?perPage=200';
-      console.log('[XPService] 🔍 Fetching XP history URL:', url);
-
-      const headers: Record<string, string> = {};
-      if (pb.authStore.token) {
-        headers['Authorization'] = `Bearer ${pb.authStore.token}`;
-      }
-      const response = await fetch(url, { headers });
-
-      console.log('[XPService] 📡 getXPHistory response status:', response.status, response.ok);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[XPService] ❌ getXPHistory fetch failed:", response.status, errorText);
-        return [];
-      }
-
-      const data = await response.json();
-      const allTransactions = data.items || [];
-
-      // Sort by created date descending in JS
-      const sortedTransactions = allTransactions.sort((a: any, b: any) =>
-        new Date(b.created).getTime() - new Date(a.created).getTime()
-      );
-
-      // Filter for this user
-      const userTransactions = sortedTransactions.filter((item: any) => item.user === userId);
+      // Authenticated, server-side filtered query scoped to this user's records.
+      const userTransactions = await pb.collection('xp_transactions').getFullList({
+        filter: pb.filter('user = {:userId}', { userId }),
+        sort: '-created',
+      });
 
       // Apply pagination
-      const startIdx = offset;
-      const endIdx = Math.min(startIdx + limit, userTransactions.length);
-      const paginatedTransactions = userTransactions.slice(startIdx, endIdx);
+      const paginatedTransactions = userTransactions.slice(offset, offset + limit);
 
       return paginatedTransactions.map((item: any) => ({
         id: item.id,
@@ -294,31 +269,11 @@ export class XPService {
         return 0;
       }
 
-      // Use native fetch to bypass PocketBase SDK issues in React Native
-      const url = 'https://fwf-pocketbase-production.up.railway.app/api/collections/xp_transactions/records?perPage=200';
-      console.log('[XPService] 🔍 Fetching XP for action URL:', url);
-
-      const headers: Record<string, string> = {};
-      if (pb.authStore.token) {
-        headers['Authorization'] = `Bearer ${pb.authStore.token}`;
-      }
-      const response = await fetch(url, { headers });
-
-      console.log('[XPService] 📡 getTotalXPForAction response status:', response.status, response.ok);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[XPService] ❌ getTotalXPForAction fetch failed:", response.status, errorText);
-        return 0;
-      }
-
-      const data = await response.json();
-      const allTransactions = data.items || [];
-
-      // Filter for this user and action type
-      const result = allTransactions.filter(
-        (item: any) => item.user === userId && item.action_type === actionType
-      );
+      // Authenticated, server-side filtered query for this user's records of
+      // the given action type.
+      const result = await pb.collection('xp_transactions').getFullList({
+        filter: pb.filter('user = {:userId} && action_type = {:actionType}', { userId, actionType }),
+      });
 
       return result.reduce((sum: number, transaction: any) => sum + (transaction.amount || 0), 0);
 
@@ -337,29 +292,10 @@ export class XPService {
         return {};
       }
 
-      // Use native fetch to bypass PocketBase SDK issues in React Native
-      const url = 'https://fwf-pocketbase-production.up.railway.app/api/collections/xp_transactions/records?perPage=200';
-      console.log('[XPService] 🔍 Fetching XP statistics URL:', url);
-
-      const headers: Record<string, string> = {};
-      if (pb.authStore.token) {
-        headers['Authorization'] = `Bearer ${pb.authStore.token}`;
-      }
-      const response = await fetch(url, { headers });
-
-      console.log('[XPService] 📡 getXPStatistics response status:', response.status, response.ok);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[XPService] ❌ getXPStatistics fetch failed:", response.status, errorText);
-        return {};
-      }
-
-      const data = await response.json();
-      const allTransactions = data.items || [];
-
-      // Filter for this user
-      const result = allTransactions.filter((item: any) => item.user === userId);
+      // Authenticated, server-side filtered query scoped to this user's records.
+      const result = await pb.collection('xp_transactions').getFullList({
+        filter: pb.filter('user = {:userId}', { userId }),
+      });
 
       const stats: Record<string, number> = {};
       result.forEach((transaction: any) => {
@@ -385,33 +321,13 @@ export class XPService {
     try {
       if (!userId) return false;
 
-      // Use native fetch to bypass PocketBase SDK issues in React Native
-      // Hardcode URL for testing
-      const url = 'https://fwf-pocketbase-production.up.railway.app/api/collections/xp_transactions/records?perPage=100';
-      console.log('[XPService] 🔍 Fetching URL:', url);
-
-      const headers: Record<string, string> = {};
-      if (pb.authStore.token) {
-        headers['Authorization'] = `Bearer ${pb.authStore.token}`;
-      }
-      const response = await fetch(url, { headers });
-
-      console.log('[XPService] 📡 Response status:', response.status, response.ok);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[XPService] ❌ Fetch failed:", response.status, errorText);
-        return false;
-      }
-
-      const data = await response.json();
-      console.log('[XPService] ✅ Data received, items count:', data.items?.length || 0);
-      const items = data.items || [];
-
-      // Filter for this user's daily_use transactions in JS
-      const userDailyTransactions = items.filter(
-        (item: any) => item.user === userId && item.action_type === 'daily_use'
-      );
+      // Authenticated, server-side filtered query for this user's daily rewards.
+      const userDailyTransactions = await pb.collection('xp_transactions').getFullList({
+        filter: pb.filter('user = {:userId} && action_type = {:actionType}', {
+          userId,
+          actionType: 'daily_use',
+        }),
+      });
 
       if (userDailyTransactions.length === 0) {
         return true; // No daily XP transactions ever


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-applies the correctness fixes (originally done against stale `main`) on top of the active **SDK 55** trunk. I confirmed none of these were already present here.

- **Plants never grew** — `GardenService.plantSeed` didn't set `planted_at`, so it stored empty and growth (computed from `planted_at`) always saw 0 elapsed hours → stuck at stage 2. Now sets `planted_at`.
- **`XPService` fetched a hardcoded prod URL** — `getXPHistory`/`getTotalXPForAction`/`getXPStatistics`/`canReceiveDailyXP` hit `https://fwf-pocketbase-production.up.railway.app/...` and pulled *all users'* transactions before filtering client-side (ignores `EXPO_PUBLIC_POCKETBASE_URL`, exposes other users' data, and the 100-row cap made the daily check unreliable). This branch had added an auth header but kept the hardcoded URL + client-side filtering. Replaced with authenticated `pb.collection('xp_transactions')` queries filtered server-side via `pb.filter()`.
- **`country_code` never persisted** — `phone-number-add` now saves the country picker's `cca2`; contact matching relies on it and previously always defaulted to US.
- **No `phone_number` uniqueness** — added a partial unique index (`WHERE phone_number != ''`) via a guarded migration + the committed schema, so two accounts can't claim the same number while empty in-progress signups don't collide.

## Testing
- ✅ `npx tsc --noEmit` — no type errors in the edited files on SDK 55.
- ✅ **XPService** query pattern verified against local PocketBase: only the target user's rows returned; `getTotalXPForAction` = `20` (excludes another user's `999`); daily check `false` after a same-day reward; no cross-user leak.
- ✅ **Phone-index migration** on a prod-like local PocketBase (`phone_number` present): index created, and a duplicate non-empty phone number is rejected (400); boots cleanly.
- `planted_at` / `country_code` are type-checked; their behavior is identical to the versions verified end-to-end previously (growth pure-function test; UI signup persisting `country_code: GB`).

## Note on migration shipping
This PR intentionally does **not** modify the `Dockerfile`. The `pb_migrations` shipping wiring (`COPY pb_migrations` + `--migrationsDir`) is introduced by the notifications PR (#63). Once that's merged, the `pb_migrations` directory (including this PR's phone-index migration) auto-applies on deploy. If this merges before #63, the migration file is present but only ships to prod once #63's Dockerfile change lands. The two PRs touch disjoint files except `pocketbase-deploy/pb_schema.json`, where the edits are in different regions (a field vs the indexes array) and auto-merge cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

