### PR TITLE
Port dev-environment setup (AGENTS.md + local PocketBase script) to SDK 55

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Fair Weather Friends (`fwf`) is an **Expo SDK 55 / React Native 0.83** app backed by a
+**PocketBase** server and the **OpenWeatherMap** API. Standard dev/test/lint/build
+commands live in `package.json` scripts and `CLAUDE.md`; the notes below cover the
+non-obvious, environment-specific bits.
+
+### Dependencies
+- Install with **`npm install --legacy-peer-deps`** — the project has peer-dependency
+  conflicts and a plain `npm install` fails. Use the same flag when adding packages, and
+  prefer `npx expo install <pkg>`'s resolved version (SDK 55 uses SDK-aligned versions,
+  e.g. `expo-notifications@~55.x`).
+
+### Backend: local PocketBase
+- The app defaults `EXPO_PUBLIC_POCKETBASE_URL` to `http://localhost:8080`
+  (`app.config.js`); production is the Railway URL. Run a local PocketBase on 8080 for full
+  functionality.
+- Serve it with the hooks and migrations directories enabled so server-side features work:
+  `pocketbase serve --http=0.0.0.0:8080 --dir <data-dir> --hooksDir <repo>/pb_hooks --migrationsDir <repo>/pb_migrations`
+  (run it in a tmux session so it stays up).
+- Apply the collection schema to a fresh instance with
+  `node scripts/setup-local-pocketbase.mjs` — idempotent; reads
+  `pocketbase-deploy/pb_schema.json`, opens the `users` sign-up rule, and creates all base
+  collections plus `created`/`updated` autodate fields (PocketBase 0.23+ doesn't auto-add
+  those, and the app sorts by `created`). Defaults: superuser `admin@fwf.local` /
+  `adminpassword123`, `PB_URL=http://localhost:8080` (override via env vars).
+
+### Server-side PocketBase code (hooks + migrations)
+- `pb_hooks/*.pb.js` and `pb_migrations/*.js` ship into the Docker image (`Dockerfile`) and
+  load via `--hooksDir` / `--migrationsDir`; PocketBase automigrate applies pending
+  migrations on startup. The Railway instance is updated by redeploying the image.
+- `pb_hooks/garden_activity_push.pb.js` sends Expo push notifications when a friend plants
+  in or harvests from a user's garden. For local testing without real devices, set
+  `EXPO_PUSH_API_URL` to a local HTTP listener to capture the push payloads.
+
+### Running the app
+- iOS is the primary target: **`npx expo run:ios`** (builds the dev client, required
+  because the app uses native modules such as `expo-notifications`). After adding or
+  upgrading a native dependency, do a full `expo run:ios` rebuild — a plain `expo start`
+  against a stale build errors with "native module doesn't exist".
+- `.env` (git-ignored) holds `EXPO_PUBLIC_POCKETBASE_URL`, `EXPO_PUBLIC_OPENWEATHER_API_KEY`,
+  and optional PostHog keys. Weather/home need the OpenWeather key; sign-up and early
+  onboarding work without it.
+
+### Push notifications
+- Delivery requires a physical device + dev/EAS build — Expo Go and the iOS Simulator
+  can't receive remote push. The client registration no-ops on non-devices, so simulator
+  work is unaffected.
+- The prod schema bits notifications rely on (`push_token` field, plus the `phone_number`
+  unique index) are applied automatically by `pb_migrations` on the next Railway deploy;
+  ensure `/pb/pb_data` is a persistent Railway volume so schema/data survive redeploys.

--- a/scripts/setup-local-pocketbase.mjs
+++ b/scripts/setup-local-pocketbase.mjs
@@ -1,0 +1,187 @@
+// Idempotent local PocketBase schema setup for Fair Weather Friends.
+//
+// Reads pocketbase-deploy/pb_schema.json (legacy PB export format) and applies
+// it to a locally running PocketBase instance via the admin API, translating
+// the legacy `schema`/`options` format to the current `fields` format.
+//
+// Usage (PocketBase must already be running):
+//   node scripts/setup-local-pocketbase.mjs
+//
+// Environment variables (all optional, defaults shown):
+//   PB_URL=http://localhost:8080
+//   PB_ADMIN_EMAIL=admin@fwf.local
+//   PB_ADMIN_PASSWORD=adminpassword123
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PB_URL = process.env.PB_URL || "http://localhost:8080";
+const PB_ADMIN_EMAIL = process.env.PB_ADMIN_EMAIL || "admin@fwf.local";
+const PB_ADMIN_PASSWORD = process.env.PB_ADMIN_PASSWORD || "adminpassword123";
+
+const schemaPath = path.join(__dirname, "..", "pocketbase-deploy", "pb_schema.json");
+const legacy = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+
+let token = "";
+const nameToId = {};
+
+async function api(method, endpoint, body) {
+    const res = await fetch(`${PB_URL}${endpoint}`, {
+        method,
+        headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: token } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    let json;
+    try { json = text ? JSON.parse(text) : {}; } catch { json = { raw: text }; }
+    if (!res.ok) {
+        throw new Error(`${method} ${endpoint} -> ${res.status}: ${JSON.stringify(json)}`);
+    }
+    return json;
+}
+
+function translateField(f) {
+    const base = { name: f.name, type: f.type, required: !!f.required };
+    const o = f.options || {};
+    switch (f.type) {
+        case "text":
+        case "number":
+        case "bool":
+        case "date":
+            return base;
+        case "json":
+            return { ...base, maxSize: o.maxSize || 2000000 };
+        case "file":
+            return {
+                ...base,
+                maxSelect: o.maxSelect || 1,
+                maxSize: o.maxSize || 5242880,
+                mimeTypes: o.mimeTypes || [],
+            };
+        case "select":
+            return { ...base, maxSelect: o.maxSelect || 1, values: o.values || [] };
+        case "relation": {
+            const collectionId = nameToId[o.collectionId] || o.collectionId;
+            return {
+                ...base,
+                collectionId,
+                cascadeDelete: !!o.cascadeDelete,
+                maxSelect: o.maxSelect || 1,
+            };
+        }
+        default:
+            return base;
+    }
+}
+
+async function ensureUsersCollection(def) {
+    const list = await api("GET", "/api/collections?perPage=200");
+    const existing = list.items.find((c) => c.name === "users");
+    if (!existing) throw new Error("Default 'users' auth collection not found");
+    nameToId["users"] = existing.id;
+
+    const existingNames = new Set(existing.fields.map((f) => f.name));
+    const newFields = def.schema
+        .filter((f) => !existingNames.has(f.name))
+        .map(translateField);
+
+    // Merge our extra indexes (e.g. unique phone_number) with PocketBase's
+    // built-in ones (unique email/tokenKey) so we don't drop the defaults.
+    const existingIndexes = existing.indexes || [];
+    const extraIndexes = (def.indexes || []).filter(
+        (idx) => !existingIndexes.includes(idx)
+    );
+
+    const payload = {
+        fields: [...existing.fields, ...newFields],
+        indexes: [...existingIndexes, ...extraIndexes],
+        // Allow public sign-up and let authenticated users read profiles (needed for friends).
+        createRule: "",
+        listRule: "@request.auth.id != ''",
+        viewRule: "@request.auth.id != ''",
+        updateRule: "@request.auth.id = id",
+    };
+    await api("PATCH", `/api/collections/${existing.id}`, payload);
+    console.log(
+        `users: ensured (${newFields.length} custom field(s), ${extraIndexes.length} extra index(es) added)`
+    );
+}
+
+// PocketBase 0.23+ no longer auto-creates created/updated fields; the app sorts
+// by `created` (e.g. XP history, activity feed), so add them explicitly.
+const AUTODATE_FIELDS = [
+    { name: "created", type: "autodate", onCreate: true, onUpdate: false },
+    { name: "updated", type: "autodate", onCreate: true, onUpdate: true },
+];
+
+async function ensureBaseCollection(def) {
+    const list = await api("GET", "/api/collections?perPage=200");
+    const existing = list.items.find((c) => c.name === def.name);
+    if (existing) {
+        nameToId[def.name] = existing.id;
+        // Backfill created/updated autodate fields if a prior run created the
+        // collection without them.
+        const existingNames = new Set(existing.fields.map((f) => f.name));
+        const missing = AUTODATE_FIELDS.filter((f) => !existingNames.has(f.name));
+        if (missing.length > 0) {
+            await api("PATCH", `/api/collections/${existing.id}`, {
+                fields: [...existing.fields, ...missing],
+            });
+            console.log(`${def.name}: added ${missing.map((f) => f.name).join(", ")}`);
+        } else {
+            console.log(`${def.name}: already exists, skipping`);
+        }
+        return;
+    }
+    const fields = [...def.schema.map(translateField), ...AUTODATE_FIELDS];
+    const payload = {
+        name: def.name,
+        type: "base",
+        fields,
+        // Permissive rules for local development.
+        listRule: "@request.auth.id != ''",
+        viewRule: "@request.auth.id != ''",
+        createRule: "@request.auth.id != ''",
+        updateRule: "@request.auth.id != ''",
+        deleteRule: "@request.auth.id != ''",
+        ...(def.indexes ? { indexes: def.indexes } : {}),
+    };
+    const created = await api("POST", "/api/collections", payload);
+    nameToId[def.name] = created.id;
+    console.log(`${def.name}: created`);
+}
+
+async function main() {
+    const auth = await api("POST", "/api/collections/_superusers/auth-with-password", {
+        identity: PB_ADMIN_EMAIL,
+        password: PB_ADMIN_PASSWORD,
+    });
+    token = auth.token;
+
+    // Pre-populate name->id for existing collections so relations resolve.
+    const list = await api("GET", "/api/collections?perPage=200");
+    for (const c of list.items) nameToId[c.name] = c.id;
+
+    for (const def of legacy) {
+        if (def.type === "auth" && def.name === "users") {
+            await ensureUsersCollection(def);
+        }
+    }
+    // Base collections in file order (users & plants precede their dependents).
+    for (const def of legacy) {
+        if (def.type === "base") {
+            await ensureBaseCollection(def);
+        }
+    }
+    console.log("PocketBase schema setup complete.");
+}
+
+main().catch((err) => {
+    console.error(err.message || err);
+    process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings #58's local-dev tooling onto the new SDK-55 `main` (it only ever lived on the old SDK-53 `main`, so the SDK-55 trunk was missing it).

- `scripts/setup-local-pocketbase.mjs` — idempotent helper that applies `pocketbase-deploy/pb_schema.json` to a local PocketBase (translates the legacy export format, opens the `users` sign-up rule, creates all base collections + `created`/`updated` autodate fields, and merges the `phone_number` unique index).
- `AGENTS.md` — rewritten for SDK 55: `npm install --legacy-peer-deps`, running local PocketBase with `--hooksDir`/`--migrationsDir`, the `garden_activity_push` hook + `EXPO_PUSH_API_URL` local-test override, iOS dev-build / native-rebuild guidance, and push-notification device caveats. Deliberately **drops** the stale SDK-53 caveats (web `lottie`/`react-async-hook` fixes, the reanimated pin, and the old supabase jest-mock note) since none apply on this branch (verified: no `@lottiefiles/dotlottie-react`/overrides, no supabase reference in `jest.setup.js`).

## Testing
- ✅ Ran `scripts/setup-local-pocketbase.mjs` against a fresh local PocketBase using the current SDK-55 `pocketbase-deploy/pb_schema.json`: applied the 22 custom `users` fields (incl. `push_token`), the `phone_number` unique index, and all base collections — no errors.
- Docs-only otherwise (`AGENTS.md`).

Targets the new `main` (SDK 55).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1083c292-85ac-4a6d-85b7-3b87170a6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

